### PR TITLE
Block stream improvement

### DIFF
--- a/lib/block-stream.js
+++ b/lib/block-stream.js
@@ -29,9 +29,9 @@ class BlockStream extends TransformStream {
     this._chunkSize = options.chunkSize;
     this._addPadding = options.padLastChunk;
     this._bufferLength = 0;
-    this._chunkOffset = 0;
-    this._queueHead = null;
-    this._queueTail = null;
+    this._offset = 0;
+    this._head = null;
+    this._tail = null;
   }
 
   /**
@@ -69,7 +69,7 @@ class BlockStream extends TransformStream {
 
     var i = 0;
     while(this._bufferLength > 0) {
-      const k = (this._queueHead.chunk.length - this._chunkOffset);
+      const k = (this._head.chunk.length - this._offset);
       this._drainChunk(chunk, i);
       i += k;
       this._bufferLength -= k;
@@ -83,22 +83,29 @@ class BlockStream extends TransformStream {
    * @private
    */
   _drainInternalBuffer() {
-    while (this._bufferLength >= this._chunkSize) {
-      const chunk = Buffer.allocUnsafe(this._chunkSize);
+    const self = this;
+    
+    function _transformChunk() {
+      const chunk = Buffer.allocUnsafe(self._chunkSize);
       var i = 0;
-      var j = this._chunkSize;
-      while (i < this._chunkSize) {
-        const k = (this._queueHead.chunk.length - this._chunkOffset);
+      var j = self._chunkSize;
+      while (i < self._chunkSize) {
+        const k = (self._head.chunk.length - self._offset);
         if (j >= k) {
-          this._drainChunk(chunk, i);
+          self._drainChunk(chunk, i);
           i += k;
           j -= k;
         } else {
-          this._queueHead.chunk.copy(chunk, i, this._chunkOffset, this._chunkOffset + j);
-          this._chunkOffset += j;
+          self._head.chunk.copy(chunk, i, self._offset, self._offset + j);
+          self._offset += j;
           i += j;
-        }          
+        }
       }
+      return chunk;
+    }
+
+    while (this._bufferLength >= this._chunkSize) {
+      const chunk = _transformChunk();    
       this.push(chunk);
       this._bufferLength -= this._chunkSize;
     }
@@ -110,12 +117,12 @@ class BlockStream extends TransformStream {
    */
   _addToBuffer(bytes) {
     const entry = { chunk: bytes, next: null };
-    if (this._queueTail === null) {
-      this._queueHead = entry;
+    if (this._tail === null) {
+      this._head = entry;
     } else {
-      this._queueTail.next = entry;
+      this._tail.next = entry;
     }
-    this._queueTail = entry;
+    this._tail = entry;
     this._bufferLength += bytes.length;
   }
 
@@ -124,13 +131,13 @@ class BlockStream extends TransformStream {
    * @private
    */
   _drainChunk(chunk, i) {
-    this._queueHead.chunk.copy(chunk, i, this._chunkOffset);
-    this._chunkOffset = 0;
-    if(this._queueHead.next === null) {
-      this._queueHead = null;
-      this._queueTail = null;
+    this._head.chunk.copy(chunk, i, this._offset);
+    this._offset = 0;
+    if(this._head.next === null) {
+      this._head = null;
+      this._tail = null;
     } else {
-      this._queueHead = this._queueHead.next;
+      this._head = this._head.next;
     }
   }
 

--- a/lib/block-stream.js
+++ b/lib/block-stream.js
@@ -28,7 +28,10 @@ class BlockStream extends TransformStream {
     options = merge(BlockStream.DEFAULTS, options);
     this._chunkSize = options.chunkSize;
     this._addPadding = options.padLastChunk;
-    this._currentBuffer = new Buffer([]);
+    this._bufferLength = 0;
+    this._chunkOffset = 0;
+    this._queueHead = null;
+    this._queueTail = null;
   }
 
   /**
@@ -57,18 +60,21 @@ class BlockStream extends TransformStream {
    * @private
    */
   _flush(callback) {
-    if (this._currentBuffer.length === 0) {
+    if(this._bufferLength === 0) {
       return callback(null);
     }
+    const chunk = (this._addPadding && this._chunkSize !== this._bufferLength)
+        ? Buffer.allocUnsafe(this._chunkSize).fill(0, this._bufferLength)
+        : Buffer.allocUnsafe(this._bufferLength);
 
-    if (this._addPadding) {
-      this._addToBuffer(
-        Buffer(this._chunkSize - this._currentBuffer.length).fill(0)
-      );
+    var i = 0;
+    while(this._bufferLength > 0) {
+      const k = (this._queueHead.chunk.length - this._chunkOffset);
+      this._drainChunk(chunk, i);
+      i += k;
+      this._bufferLength -= k;
     }
-
-    this.push(this._currentBuffer);
-    this._currentBuffer = Buffer([]);
+    this.push(chunk);
     callback(null);
   }
 
@@ -77,17 +83,24 @@ class BlockStream extends TransformStream {
    * @private
    */
   _drainInternalBuffer() {
-    if (this._currentBuffer.length < this._chunkSize) {
-      return;
-    }
-
-    var fullSlices = Math.floor(this._currentBuffer.length / this._chunkSize);
-    var pushSlices = 0;
-
-    while (pushSlices < fullSlices) {
-      this.push(this._currentBuffer.slice(0, this._chunkSize));
-      this._currentBuffer = this._currentBuffer.slice(this._chunkSize);
-      pushSlices++;
+    while (this._bufferLength >= this._chunkSize) {
+      const chunk = Buffer.allocUnsafe(this._chunkSize);
+      var i = 0;
+      var j = this._chunkSize;
+      while (i < this._chunkSize) {
+        const k = (this._queueHead.chunk.length - this._chunkOffset);
+        if (j >= k) {
+          this._drainChunk(chunk, i);
+          i += k;
+          j -= k;
+        } else {
+          this._queueHead.chunk.copy(chunk, i, this._chunkOffset, this._chunkOffset + j);
+          this._chunkOffset += j;
+          i += j;
+        }          
+      }
+      this.push(chunk);
+      this._bufferLength -= this._chunkSize;
     }
   }
 
@@ -96,7 +109,29 @@ class BlockStream extends TransformStream {
    * @private
    */
   _addToBuffer(bytes) {
-    this._currentBuffer = Buffer.concat([this._currentBuffer, bytes]);
+    const entry = { chunk: bytes, next: null };
+    if (this._queueTail === null) {
+      this._queueHead = entry;
+    } else {
+      this._queueTail.next = entry;
+    }
+    this._queueTail = entry;
+    this._bufferLength += bytes.length;
+  }
+
+  /**
+   * Completely drain one chunk
+   * @private
+   */
+  _drainChunk(chunk, i) {
+    this._queueHead.chunk.copy(chunk, i, this._chunkOffset);
+    this._chunkOffset = 0;
+    if(this._queueHead.next === null) {
+      this._queueHead = null;
+      this._queueTail = null;
+    } else {
+      this._queueHead = this._queueHead.next;
+    }
   }
 
 }

--- a/lib/block-stream.js
+++ b/lib/block-stream.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const {Transform: TransformStream} = require('readable-stream');
-const constants = require('./constants');
 const merge = require('merge');
-
 
 /**
  * Transforms the input stream into an output stream of N-sized chunks
@@ -12,7 +10,6 @@ class BlockStream extends TransformStream {
 
   static get DEFAULTS() {
     return {
-      chunkSize: constants.C,
       padLastChunk: false
     };
   }
@@ -20,18 +17,17 @@ class BlockStream extends TransformStream {
   /**
    * @constructor
    * @param {Object} [options]
-   * @param {Number} [options.chunkSize=constants.C] - The bytes of each chunk
+   * @param {Sbucket} [options.sBucket] - The S-bucket for chunks allocation
    * @param {Boolean} [options.padLastChunk=false] - Pad last chunk with zeros
    */
   constructor(options) {
     super();
     options = merge(BlockStream.DEFAULTS, options);
-    this._chunkSize = options.chunkSize;
     this._addPadding = options.padLastChunk;
     this._bufferLength = 0;
     this._offset = 0;
-    this._head = null;
-    this._tail = null;
+    this._inputQueue = [];
+    this._sBucket = options.sBucket;
   }
 
   /**
@@ -63,18 +59,25 @@ class BlockStream extends TransformStream {
     if(this._bufferLength === 0) {
       return callback(null);
     }
-    const chunk = (this._addPadding && this._chunkSize !== this._bufferLength)
-        ? Buffer.allocUnsafe(this._chunkSize).fill(0, this._bufferLength)
+    const chunk = (this._addPadding &&
+                   this._sBucket._chunkSize !== this._bufferLength)
+        ? ((this._sBucket._chunkFree.length > 0)
+          ? this._sBucket._chunkFree.shift()
+          : Buffer.allocUnsafe(this._sBucket._chunkSize))
+          .fill(0, this._bufferLength)
         : Buffer.allocUnsafe(this._bufferLength);
 
     var i = 0;
     while(this._bufferLength > 0) {
-      const k = (this._head.chunk.length - this._offset);
-      this._drainChunk(chunk, i);
+      const input = this._inputQueue.shift();
+      const k = (input.length - this._offset);
+      input.copy(chunk, i, this._offset);
+      this._offset = 0;
       i += k;
       this._bufferLength -= k;
     }
     this.push(chunk);
+    this._sBucket._chunkFree.splice(0, this._sBucket._chunkFree.length);
     callback(null);
   }
 
@@ -84,30 +87,33 @@ class BlockStream extends TransformStream {
    */
   _drainInternalBuffer() {
     const self = this;
-    
-    function _transformChunk() {
-      const chunk = Buffer.allocUnsafe(self._chunkSize);
+
+    function _transformChunk(chunk, j) {
       var i = 0;
-      var j = self._chunkSize;
-      while (i < self._chunkSize) {
-        const k = (self._head.chunk.length - self._offset);
+      while (i < self._sBucket._chunkSize) {
+        const input = self._inputQueue.shift();
+        const k = (input.length - self._offset);
         if (j >= k) {
-          self._drainChunk(chunk, i);
+          input.copy(chunk, i, self._offset);
+          self._offset = 0;
           i += k;
           j -= k;
         } else {
-          self._head.chunk.copy(chunk, i, self._offset, self._offset + j);
+          input.copy(chunk, i, self._offset, self._offset + j);
+          self._inputQueue.unshift(input);
           self._offset += j;
           i += j;
         }
       }
-      return chunk;
     }
 
-    while (this._bufferLength >= this._chunkSize) {
-      const chunk = _transformChunk();    
+    while (this._bufferLength >= this._sBucket._chunkSize) {
+      const chunk = (this._sBucket._chunkFree.length > 0)
+          ? this._sBucket._chunkFree.shift()
+          : Buffer.allocUnsafe(this._sBucket._chunkSize);
+      _transformChunk(chunk, this._sBucket._chunkSize);
       this.push(chunk);
-      this._bufferLength -= this._chunkSize;
+      this._bufferLength -= this._sBucket._chunkSize;
     }
   }
 
@@ -116,29 +122,8 @@ class BlockStream extends TransformStream {
    * @private
    */
   _addToBuffer(bytes) {
-    const entry = { chunk: bytes, next: null };
-    if (this._tail === null) {
-      this._head = entry;
-    } else {
-      this._tail.next = entry;
-    }
-    this._tail = entry;
+    this._inputQueue.push(bytes);
     this._bufferLength += bytes.length;
-  }
-
-  /**
-   * Completely drain one chunk
-   * @private
-   */
-  _drainChunk(chunk, i) {
-    this._head.chunk.copy(chunk, i, this._offset);
-    this._offset = 0;
-    if(this._head.next === null) {
-      this._head = null;
-      this._tail = null;
-    } else {
-      this._head = this._head.next;
-    }
   }
 
 }

--- a/lib/s-bucket.js
+++ b/lib/s-bucket.js
@@ -76,6 +76,8 @@ class Sbucket extends EventEmitter {
     this._pendingOperations = 0;
     this._maxSize = this._options.maxSize;
     this.readyState = Sbucket.CLOSED;
+    this._chunkFree = [];
+    this._chunkSize = this._options.chunkSize;
   }
 
   /**
@@ -363,8 +365,8 @@ class Sbucket extends EventEmitter {
    */
   createWriteStream(key) {
     const bs = new BlockStream({
-      chunkSize: this._options.chunkSize,
-      padLastChunk: false
+      padLastChunk: false,
+      sBucket: this
     });
     const ws = new WritableFileStream({
       sBucket: this,

--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -39,6 +39,9 @@ class WritableFileStream extends WritableStream {
     const itemKey = utils.createItemKeyFromIndex(this._fileKey, this._index);
 
     this._sBucket._db.put(itemKey, bytes, (err) => {
+
+      this._sBucket._chunkFree.push(bytes);
+
       if (err) {
         return callback(err);
       }

--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -40,7 +40,9 @@ class WritableFileStream extends WritableStream {
 
     this._sBucket._db.put(itemKey, bytes, (err) => {
 
-      this._sBucket._chunkFree.push(bytes);
+      if(bytes.length === this._sBucket._chunkSize) {
+        this._sBucket._chunkFree.push(bytes);
+      }
 
       if (err) {
         return callback(err);

--- a/test/block-stream.unit.js
+++ b/test/block-stream.unit.js
@@ -8,7 +8,13 @@ describe('BlockStream', function() {
   describe('#_flush', function() {
 
     it('should pad the last chunk with zeros', function(done) {
-      var bs = new BlockStream({ chunkSize: 12, padLastChunk: true });
+      var bs = new BlockStream({
+        sBucket: {
+          _chunkFree: [],
+          _chunkSize : 12
+        },
+        padLastChunk: true
+      });
       var buf = Buffer.from([]);
       bs.on('data', function(data) {
         buf = Buffer.concat([buf, data]);
@@ -29,7 +35,13 @@ describe('BlockStream', function() {
   describe('#_transform', function() {
 
     it('should return N-sized chunks', function(done) {
-      const bs = new BlockStream({ chunkSize: 12, padLastChunk: false });
+      const bs = new BlockStream({
+        sBucket: {
+          _chunkFree: [],
+          _chunkSize : 12
+        },
+        padLastChunk: false
+      });
       const ar = [];
       bs.on('data', data => ar.push(data));
       bs.once('end', function() {

--- a/test/block-stream.unit.js
+++ b/test/block-stream.unit.js
@@ -26,4 +26,25 @@ describe('BlockStream', function() {
 
   });
 
+  describe('#_transform', function() {
+
+    it('should return N-sized chunks', function(done) {
+      const bs = new BlockStream({ chunkSize: 12, padLastChunk: false });
+      const ar = [];
+      bs.on('data', data => ar.push(data));
+      bs.once('end', function() {
+        expect(Buffer.compare(ar.shift(), Buffer.from('ABCDEFGHIJKL'))).to.equal(0);
+        expect(Buffer.compare(ar.shift(), Buffer.from('MNOPQRSTUVWX'))).to.equal(0);
+        expect(Buffer.compare(ar.shift(), Buffer.from('YZ'))).to.equal(0);
+        done();
+      });
+      bs.write('AB');      
+      bs.write('CDEFGHIJKL');
+      bs.write('MNOPQRSTUVWXY');
+      bs.write('Z');
+      bs.end();
+    });
+
+  });  
+
 });

--- a/test/block-stream.unit.js
+++ b/test/block-stream.unit.js
@@ -33,9 +33,18 @@ describe('BlockStream', function() {
       const ar = [];
       bs.on('data', data => ar.push(data));
       bs.once('end', function() {
-        expect(Buffer.compare(ar.shift(), Buffer.from('ABCDEFGHIJKL'))).to.equal(0);
-        expect(Buffer.compare(ar.shift(), Buffer.from('MNOPQRSTUVWX'))).to.equal(0);
-        expect(Buffer.compare(ar.shift(), Buffer.from('YZ'))).to.equal(0);
+        expect(Buffer.compare(ar.shift(), Buffer.from('ABCDEFGHIJKL')))
+        .to
+        .equal(0);
+
+        expect(Buffer.compare(ar.shift(), Buffer.from('MNOPQRSTUVWX')))
+        .to
+        .equal(0);
+
+        expect(Buffer.compare(ar.shift(), Buffer.from('YZ')))
+        .to
+        .equal(0);
+
         done();
       });
       bs.write('AB');      

--- a/test/write-stream.unit.js
+++ b/test/write-stream.unit.js
@@ -15,7 +15,8 @@ describe('WritableFileStream', function() {
         sBucket: {
           _db: {
             put: sinon.stub().callsArgWith(2, new Error('Failed'))
-          }
+          },
+          _chunkFree: []
         }
       });
       ws.on('error', function(err) {


### PR DESCRIPTION
I added a test for the transformation function, and also optimized: the concatenation was replaced by the queue of incoming data blocks, which minimizes copy operations and memory usage.